### PR TITLE
Apply border radius to entire modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- The default value of `CommandPaletteStyle.borderRadius` has been changed to `BorderRadius.all(Radius.circular(5))`
+
+### Fixed
+- `CommandPaletteStyle.borderRadius` now correctly applies to the border of the entire modal, and not just the part with the actions/instructions.
+
 ## 0.6.0 - 2022-12-10
 ### Fixed
 - Semi-Breaking: Changed the type of `CommandPaletteConfig.openKeySet` and `CommandPaletteConfig.closeKeySet` from `LogicalKeySet` to `ShortcutActivator` (note: `LogicalKeySet` already implements `ShortcutActivator`, so existing custom shortcuts should still work, but a proposed solution is discussed below). This was done to fix an issue on Web builds for MacOS (discussed [here](https://github.com/TNorbury/command_palette/issues/22)). If you don't set custom values for the open and close key sets (or if you're not targeting Web), then no change will be required on your part. But if you are, the following change is suggested to make sure everything works well: If you're opening the palette with a keyboard shortcut, such as CTRL/CMD+U, then you could go from `LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyU)`/`LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.keyU)` to `SingleActivator(LogicalKeyboardKey.keyU, control: true)`/`SingleActivator(LogicalKeyboardKey.keyU, meta: true)`. This also changes how the command palette control shortcuts (Up/down/enter/backspace) are handled (from `LogicalKeySet` to `SingleActivator`). This should make things a bit cleaner on my end, and more stable going forward.
@@ -61,4 +68,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.1.0 - 2021-11-03
 ### Added
--   initial release
+- initial release

--- a/lib/src/models/command_palette_style.dart
+++ b/lib/src/models/command_palette_style.dart
@@ -63,10 +63,7 @@ class CommandPaletteStyle {
   ///
   /// Defaults to
   /// ```
-  /// BorderRadius.only(
-  ///   bottomLeft: Radius.circular(5),
-  ///   bottomRight: Radius.circular(5),
-  /// )
+  /// BorderRadius.all(Radius.circular(5))
   /// ```
   final BorderRadiusGeometry borderRadius;
 
@@ -114,10 +111,7 @@ class CommandPaletteStyle {
     this.highlightSearchSubstring = true,
     this.actionDescriptionTextStyle,
     this.elevation = 4.0,
-    this.borderRadius = const BorderRadius.only(
-      bottomLeft: Radius.circular(5),
-      bottomRight: Radius.circular(5),
-    ),
+    this.borderRadius = const BorderRadius.all(Radius.circular(5)),
     this.actionLabelTextAlign = TextAlign.left,
     this.commandPaletteBarrierColor = Colors.black12,
     this.textFieldInputDecoration,

--- a/lib/src/widgets/command_palette_text_field.dart
+++ b/lib/src/widgets/command_palette_text_field.dart
@@ -54,8 +54,8 @@ class _CommandPaletteTextFieldState extends State<CommandPaletteTextField> {
   Widget build(BuildContext context) {
     final CommandPaletteController controller =
         CommandPaletteControllerProvider.of(context);
-    InputDecoration inputDecoration =
-        controller.style.textFieldInputDecoration!;
+    final style = controller.style;
+    InputDecoration inputDecoration = style.textFieldInputDecoration!;
 
     // if no prefix was provided, the selected action is a nested action, and
     // the user indicates that they want nested actions to have prefix text,
@@ -64,7 +64,7 @@ class _CommandPaletteTextFieldState extends State<CommandPaletteTextField> {
         inputDecoration.prefixIcon == null &&
         inputDecoration.prefixText == null;
     if (styleHasNoPrefix &&
-        controller.style.prefixNestedActions &&
+        style.prefixNestedActions &&
         controller.currentlySelectedAction?.actionType ==
             CommandPaletteActionType.nested) {
       inputDecoration = inputDecoration.copyWith(
@@ -73,8 +73,13 @@ class _CommandPaletteTextFieldState extends State<CommandPaletteTextField> {
       );
     }
 
+    final radius = style.borderRadius.resolve(Directionality.of(context));
     return Material(
       elevation: 4,
+      borderRadius: BorderRadius.only(
+        topLeft: radius.topLeft,
+        topRight: radius.topRight,
+      ),
       child: TextField(
         controller: controller.textEditingController,
         textInputAction: TextInputAction.done,

--- a/lib/src/widgets/options/command_palette_body.dart
+++ b/lib/src/widgets/options/command_palette_body.dart
@@ -18,10 +18,14 @@ class CommandPaletteBody extends StatelessWidget {
     CommandPaletteController controller =
         CommandPaletteControllerProvider.of(context);
     List<CommandPaletteAction> actions = controller.getFilteredActions();
-
+    final borderRadius =
+        controller.style.borderRadius.resolve(Directionality.of(context));
     return Material(
       elevation: controller.style.elevation,
-      borderRadius: controller.style.borderRadius,
+      borderRadius: BorderRadius.only(
+        bottomLeft: borderRadius.bottomLeft,
+        bottomRight: borderRadius.bottomRight,
+      ),
       clipBehavior: Clip.antiAlias,
       child: Column(
         mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
fixes #24

Applies `CommandPaletteStyle.borderRadius` to the entire modal, and not just the actions/instructions part. 