### PR TITLE
Add barrierFilter to CP Style to set the filter being used by the Mod…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
-- Added `CommandPaletteStyle.barrierFilter`, which is an option `ImageFilter` which can be used to add an effect (usually a blurring) behind the command palette when it's open
+- Added `CommandPaletteStyle.barrierFilter`, which is an optional `ImageFilter` which can be used to add an effect (usually a blurring) behind the command palette when it's open
 
 ## 0.6.0 - 2022-12-10
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Added `CommandPaletteStyle.barrierFilter`, which is an option `ImageFilter` which can be used to add an effect (usually a blurring) behind the command palette when it's open
+
 ## 0.6.0 - 2022-12-10
 ### Fixed
 - Semi-Breaking: Changed the type of `CommandPaletteConfig.openKeySet` and `CommandPaletteConfig.closeKeySet` from `LogicalKeySet` to `ShortcutActivator` (note: `LogicalKeySet` already implements `ShortcutActivator`, so existing custom shortcuts should still work, but a proposed solution is discussed below). This was done to fix an issue on Web builds for MacOS (discussed [here](https://github.com/TNorbury/command_palette/issues/22)). If you don't set custom values for the open and close key sets (or if you're not targeting Web), then no change will be required on your part. But if you are, the following change is suggested to make sure everything works well: If you're opening the palette with a keyboard shortcut, such as CTRL/CMD+U, then you could go from `LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyU)`/`LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.keyU)` to `SingleActivator(LogicalKeyboardKey.keyU, control: true)`/`SingleActivator(LogicalKeyboardKey.keyU, meta: true)`. This also changes how the command palette control shortcuts (Up/down/enter/backspace) are handled (from `LogicalKeySet` to `SingleActivator`). This should make things a bit cleaner on my end, and more stable going forward.
@@ -61,4 +65,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.1.0 - 2021-11-03
 ### Added
--   initial release
+- initial release

--- a/lib/src/command_palette.dart
+++ b/lib/src/command_palette.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 import '../command_palette.dart';
 import 'controller/command_palette_controller.dart';
@@ -209,6 +208,7 @@ class _CommandPaletteInnerState extends State<_CommandPaletteInner> {
       prefixNestedActions: styleToCopy.prefixNestedActions,
       instructionColor: styleToCopy.instructionColor ??
           newActionLabelTextStyle?.color?.withOpacity(.84),
+      barrierFilter: styleToCopy.barrierFilter,
     );
 
     widget.controller.style = _style;
@@ -267,6 +267,7 @@ class _CommandPaletteInnerState extends State<_CommandPaletteInner> {
             transitionCurve: widget.config.transitionCurve,
             transitionDuration: widget.config.transitionDuration,
             closeKeySet: widget.config.closeKeySet,
+            filter: widget.config.style?.barrierFilter,
           ),
         )
         .then(

--- a/lib/src/models/command_palette_style.dart
+++ b/lib/src/models/command_palette_style.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 
 /// Used to style a [CommandPalette]
@@ -80,6 +82,10 @@ class CommandPaletteStyle {
   /// Defaults to `Colors.black12`
   final Color commandPaletteBarrierColor;
 
+  /// Filter to apply behind the command pallette when it's open. Is used to set
+  /// [ModalRoute.filter].
+  final ImageFilter? barrierFilter;
+
   /// Decoration used for the text field
   ///
   /// Defaults to
@@ -123,6 +129,7 @@ class CommandPaletteStyle {
     this.textFieldInputDecoration,
     this.prefixNestedActions = true,
     this.instructionColor,
+    this.barrierFilter,
   });
 
   @override
@@ -142,7 +149,8 @@ class CommandPaletteStyle {
         other.commandPaletteBarrierColor == commandPaletteBarrierColor &&
         other.textFieldInputDecoration == textFieldInputDecoration &&
         other.prefixNestedActions == prefixNestedActions &&
-        other.instructionColor == instructionColor;
+        other.instructionColor == instructionColor &&
+        other.barrierFilter == barrierFilter;
   }
 
   @override
@@ -159,7 +167,8 @@ class CommandPaletteStyle {
         commandPaletteBarrierColor.hashCode ^
         textFieldInputDecoration.hashCode ^
         prefixNestedActions.hashCode ^
-        instructionColor.hashCode;
+        instructionColor.hashCode ^
+        barrierFilter.hashCode;
   }
 }
 

--- a/lib/src/models/command_palette_style.dart
+++ b/lib/src/models/command_palette_style.dart
@@ -82,7 +82,7 @@ class CommandPaletteStyle {
   /// Defaults to `Colors.black12`
   final Color commandPaletteBarrierColor;
 
-  /// Filter to apply behind the command pallette when it's open. Is used to set
+  /// Filter to apply behind the command palette when it's open. It's used to set
   /// [ModalRoute.filter].
   final ImageFilter? barrierFilter;
 

--- a/lib/src/widgets/command_palette_modal.dart
+++ b/lib/src/widgets/command_palette_modal.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: body_might_complete_normally_nullable
 
+import 'dart:ui';
+
 import 'package:command_palette/src/controller/command_palette_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -43,8 +45,10 @@ class CommandPaletteModal extends ModalRoute<void> {
     required Duration transitionDuration,
     required Curve transitionCurve,
     required this.closeKeySet,
+    ImageFilter? filter,
   })  : _transitionDuration = transitionDuration,
-        _transitionCurve = transitionCurve;
+        _transitionCurve = transitionCurve,
+        super(filter: filter);
 
   @override
   Color? get barrierColor =>


### PR DESCRIPTION
closes #25

Adds a `barrierFilter` to `CommandPaletteStyle` to set the `ImageFilter` that will go behind the command palette when it's open.


Luckily `ModalRoute`, which is what wraps around the command palette when it's open, has an argument [`filter`](https://api.flutter.dev/flutter/widgets/ModalRoute/filter.html) in its constructor, so this ended up being a super simple change 🥂 